### PR TITLE
Fix memory leak on raw rpc call

### DIFF
--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -229,7 +229,11 @@ export class RpcCore {
 
         return (): void => {
           // delete old results from cache
-          memoized?.unmemoize(...values);
+          if (isScale) {
+            memoized?.unmemoize(...values);
+          } else {
+            memoized?.raw.unmemoize(...values);
+          }
         };
       }).pipe(
         publishReplay(1), // create a Replay(1)


### PR DESCRIPTION
While processing a raw rpc call an observable is removed from the wrong cache. It causes a memory leak.